### PR TITLE
feat: add disk size autoscaling, restore, autofailover, and backup retention

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -35,6 +35,12 @@ module "postgresql_cluster" {
   disk_size           = 16
   deletion_protection = false
 
+  disk_size_autoscaling = {
+    disk_size_limit           = 200
+    planned_usage_threshold   = 70
+    emergency_usage_threshold = 90
+  }
+
   hosts = [
     {
       zone             = "ru-central1-a"
@@ -117,6 +123,9 @@ module "postgresql_cluster" {
   user_conn_limit          = 50
   user_settings            = {}
   user_deletion_protection = false
+
+  autofailover = true
+  backup_retain_period_days = 14
 
   depends_on = [module.network]
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,15 @@ resource "yandex_mdb_postgresql_cluster" "postgresql_cluster" {
   security_group_ids  = var.security_group_ids
   deletion_protection = var.deletion_protection
 
+  dynamic "restore" {
+    for_each = var.restore != null ? [var.restore] : []
+    content {
+      backup_id       = restore.value.backup_id
+      time            = restore.value.time
+      time_inclusive  = restore.value.time_inclusive
+    }
+  }
+
   config {
     version = var.postgresql_version
     resources {
@@ -51,6 +60,18 @@ resource "yandex_mdb_postgresql_cluster" "postgresql_cluster" {
         pooling_mode = pooler_config.value.pooling_mode
       }
     }
+
+    dynamic "disk_size_autoscaling" {
+      for_each = var.disk_size_autoscaling != null ? [var.disk_size_autoscaling] : []
+      content {
+        disk_size_limit           = disk_size_autoscaling.value.disk_size_limit
+        planned_usage_threshold   = disk_size_autoscaling.value.planned_usage_threshold
+        emergency_usage_threshold = disk_size_autoscaling.value.emergency_usage_threshold
+      }
+    }
+
+    autofailover = var.autofailover
+    backup_retain_period_days = var.backup_retain_period_days
   }
 
   dynamic "host" {

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,35 @@ variable "user_deletion_protection" {
   type        = bool
   default     = false
 }
+
+variable "restore" {
+  description = "The cluster will be created from the specified backup"
+  type = object({
+    backup_id       = string
+    time            = optional(string)
+    time_inclusive  = optional(bool)
+  })
+  default = null
+}
+
+variable "disk_size_autoscaling" {
+  description = "Cluster disk size autoscaling settings"
+  type = object({
+    disk_size_limit           = number
+    planned_usage_threshold   = number
+    emergency_usage_threshold = number
+  })
+  default = null
+}
+
+variable "autofailover" {
+  description = "Configuration setting which enables/disables autofailover in cluster"
+  type        = bool
+  default     = true
+}
+
+variable "backup_retain_period_days" {
+  description = "The period in days during which backups are stored"
+  type        = number
+  default     = 7
+}


### PR DESCRIPTION
This pull request introduces several new features and configurations to the PostgreSQL cluster module:

1. **Disk Size Autoscaling**:
   - Adds support for automatic scaling of disk size based on usage thresholds.
   - Configuration includes:
     - `disk_size_limit`: Maximum disk size limit.
     - `planned_usage_threshold`: Threshold for planned disk size increase.
     - `emergency_usage_threshold`: Threshold for emergency disk size increase.

2. **Restore from Backup**:
   - Enables the cluster to be created from a specified backup.
   - Configuration includes:
     - `backup_id`: ID of the backup to restore from.
     - `time`: Optional time to restore to.
     - `time_inclusive`: Optional flag to include or exclude the specified time.

3. **Autofailover**:
   - Adds a configuration setting to enable or disable autofailover in the cluster.
   - Default value is `true`.

4. **Backup Retention Period**:
   - Adds a configuration setting to specify the period (in days) during which backups are stored.
   - Default value is `7` days.

### Changes
- **examples/main.tf**:
  - Added example configurations for disk size autoscaling, autofailover, and backup retention period.
  
- **main.tf**:
  - Implemented dynamic blocks for `restore` and `disk_size_autoscaling`.
  - Added support for `autofailover` and `backup_retain_period_days`.

- **variables.tf**:
  - Introduced new variables for `restore`, `disk_size_autoscaling`, `autofailover`, and `backup_retain_period_days`.

Please review and provide feedback.