### PR TITLE
fix example

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -20,7 +20,7 @@ module "network" {
 
 ########
 module "postgresql_cluster" {
-  source = "../"
+  source = "../.."
 
   name        = "my-postgresql-cluster"
   environment = "PRESTABLE"

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,6 +1,6 @@
 output "id" {
   description = "ID of the PostgreSQL cluster"
-  value       = module.postgresql_cluster.id
+  value       = module.postgresql_cluster.cluster_id
 }
 
 output "name" {


### PR DESCRIPTION
fix example:
```
terraform apply
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 25, in module "postgresql_cluster":
│   25:   name        = "my-postgresql-cluster"
│ 
│ An argument named "name" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 26, in module "postgresql_cluster":
│   26:   environment = "PRESTABLE"
│ 
│ An argument named "environment" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 27, in module "postgresql_cluster":
│   27:   network_id  = module.network.vpc_id
│ 
│ An argument named "network_id" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 28, in module "postgresql_cluster":
│   28:   description = "My PostgreSQL cluster description"
│ 
│ An argument named "description" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 29, in module "postgresql_cluster":
│   29:   folder_id   = data.yandex_client_config.client.folder_id
│ 
│ An argument named "folder_id" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 31, in module "postgresql_cluster":
│   31:   postgresql_version = "15"
│ 
│ An argument named "postgresql_version" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 33, in module "postgresql_cluster":
│   33:   resource_preset_id  = "s2.micro"
│ 
│ An argument named "resource_preset_id" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 34, in module "postgresql_cluster":
│   34:   disk_type_id        = "network-ssd"
│ 
│ An argument named "disk_type_id" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 35, in module "postgresql_cluster":
│   35:   disk_size           = 16
│ 
│ An argument named "disk_size" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 36, in module "postgresql_cluster":
│   36:   deletion_protection = false
│ 
│ An argument named "deletion_protection" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 38, in module "postgresql_cluster":
│   38:   disk_size_autoscaling = {
│ 
│ An argument named "disk_size_autoscaling" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 44, in module "postgresql_cluster":
│   44:   hosts = [
│ 
│ An argument named "hosts" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 68, in module "postgresql_cluster":
│   68:   postgresql_config = {
│ 
│ An argument named "postgresql_config" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 76, in module "postgresql_cluster":
│   76:   maintenance_window = {
│ 
│ An argument named "maintenance_window" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 82, in module "postgresql_cluster":
│   82:   access = {
│ 
│ An argument named "access" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 88, in module "postgresql_cluster":
│   88:   performance_diagnostics = {
│ 
│ An argument named "performance_diagnostics" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 93, in module "postgresql_cluster":
│   93:   backup_window_start = {
│ 
│ An argument named "backup_window_start" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 97, in module "postgresql_cluster":
│   97:   pooler_config = {
│ 
│ An argument named "pooler_config" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 102, in module "postgresql_cluster":
│  102:   default_user_settings = {
│ 
│ An argument named "default_user_settings" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 107, in module "postgresql_cluster":
│  107:   databases = [
│ 
│ An argument named "databases" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 117, in module "postgresql_cluster":
│  117:   owners = [
│ 
│ An argument named "owners" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 124, in module "postgresql_cluster":
│  124:   users = [
│ 
│ An argument named "users" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 136, in module "postgresql_cluster":
│  136:   autofailover              = true
│ 
│ An argument named "autofailover" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 137, in module "postgresql_cluster":
│  137:   backup_retain_period_days = 14
│ 
│ An argument named "backup_retain_period_days" is not expected here.
╵

```