### PR TITLE
feat: ensure users wait for cluster configuration before creation

### DIFF
--- a/users.tf
+++ b/users.tf
@@ -20,6 +20,8 @@ resource "yandex_mdb_postgresql_user" "owner" {
   conn_limit          = each.value.conn_limit
   deletion_protection = each.value.deletion_protection
   settings            = merge(var.default_user_settings, each.value.settings)
+
+  depends_on = [yandex_mdb_postgresql_cluster.main]
 }
 
 resource "yandex_mdb_postgresql_user" "user" {
@@ -40,4 +42,6 @@ resource "yandex_mdb_postgresql_user" "user" {
       database_name = yandex_mdb_postgresql_database.database[permission.value].name
     }
   }
+
+  depends_on = [yandex_mdb_postgresql_cluster.main]
 }


### PR DESCRIPTION
## Problem

During cluster downscaling operations, yandex_mdb_postgresql_user resources could be created before the main cluster configuration is fully applied, leading to race conditions and creation failures. This typically occurs when:

  - Reducing cluster resources (CPU, memory, disk size)
  - Changing cluster configuration parameters
  - Modifying host configurations during scaling operations

## Solution

Added explicit depends_on = [yandex_mdb_postgresql_cluster.main] dependencies to both owner and user resources in users.tf. This ensures PostgreSQL users are only created after the cluster configuration is completely applied, preventing timing-related errors during downscale scenarios.

## Changes

  - Added dependency clause to yandex_mdb_postgresql_user.owner
  - Added dependency clause to yandex_mdb_postgresql_user.user