### PR TITLE
feat: Add password-policy to envs

### DIFF
--- a/users.tf
+++ b/users.tf
@@ -4,9 +4,9 @@ resource "random_password" "password" {
   special          = var.password_special
   min_lower        = var.password_min_lower
   min_numeric      = var.password_min_numeric
-  min_special      = var.password_min_special
+  min_special      = var.password_special ? var.password_min_special : 0
   min_upper        = var.password_min_upper
-  override_special = var.password_special_characters
+  override_special = var.password_special ? var.password_special_characters : ""
 }
 
 resource "yandex_mdb_postgresql_user" "owner" {

--- a/users.tf
+++ b/users.tf
@@ -1,12 +1,12 @@
 resource "random_password" "password" {
   for_each         = { for v in concat(var.owners, var.users) : v.name => v if v.password == null }
-  length           = 16
-  special          = true
-  min_lower        = 1
-  min_numeric      = 1
-  min_special      = 1
-  min_upper        = 1
-  override_special = "-_()[]{}!%^"
+  length           = var.password_length
+  special          = var.password_special
+  min_lower        = var.password_min_lower
+  min_numeric      = var.password_min_numeric
+  min_special      = var.password_min_special
+  min_upper        = var.password_min_upper
+  override_special = var.password_special_characters
 }
 
 resource "yandex_mdb_postgresql_user" "owner" {

--- a/variables.tf
+++ b/variables.tf
@@ -246,6 +246,12 @@ variable "password_min_numeric" {
   default     = 1
 }
 
+variable "password_special" {
+  description = "Whether to include special characters in the generated password"
+  type        = bool
+  default     = true
+}
+
 variable "password_min_special" {
   description = "Minimum number of special characters in generated password"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -222,6 +222,42 @@ variable "default_user_settings" {
   default     = {}
 }
 
+variable "password_length" {
+  description = "Length of the generated password"
+  type        = number
+  default     = 16
+}
+
+variable "password_special_characters" {
+  description = "String of special characters to use in generated passwords"
+  type        = string
+  default     = "-_()[]{}!%^"
+}
+
+variable "password_min_lower" {
+  description = "Minimum number of lowercase letters in generated password"
+  type        = number
+  default     = 1
+}
+
+variable "password_min_numeric" {
+  description = "Minimum number of numeric digits in generated password"
+  type        = number
+  default     = 1
+}
+
+variable "password_min_special" {
+  description = "Minimum number of special characters in generated password"
+  type        = number
+  default     = 1
+}
+
+variable "password_min_upper" {
+  description = "Minimum number of uppercase letters in generated password"
+  type        = number
+  default     = 1
+}
+
 variable "owners" {
   description = <<EOF
     List of special PostgreSQL DB users - database owners. These users are created first and assigned to database as owner.


### PR DESCRIPTION
В текущий момент в users.tf захардкожены все значения для пароля
Добавлено:
Переменные:
`password_length: Длина пароля : 16`
`password_special: Использовать ли спецсимволы : true`
`password_special_characters: Набор спецсимволов : -_()[]{}!%^`
`password_min_lower: Минимум строчных букв : 1`
`password_min_upper: Минимум заглавных букв : 1`
`password_min_numeric: Минимум цифр : 1`
`password_min_special: Минимум спецсимволов : 1`
